### PR TITLE
지갑 모듈 충전,출금,송금 구현

### DIFF
--- a/src/main/kotlin/tech/sipe/fintech/common/DomainEvent.kt
+++ b/src/main/kotlin/tech/sipe/fintech/common/DomainEvent.kt
@@ -1,0 +1,5 @@
+package tech.sipe.fintech.common
+
+interface DomainEvent {
+	// 추후 eventId 혹은 이벤트발행시점이 필요할 경우 필드 추가
+}

--- a/src/main/kotlin/tech/sipe/fintech/external/ExternalTransferApi.kt
+++ b/src/main/kotlin/tech/sipe/fintech/external/ExternalTransferApi.kt
@@ -1,0 +1,12 @@
+package tech.sipe.fintech.external
+
+interface ExternalTransferApi {
+	/**
+	 * 계좌간 이체
+	 */
+	fun transfer(
+		sourceAccountNumber: String,
+		destinationAccountNumber: String,
+		amount: Long,
+	)
+}

--- a/src/main/kotlin/tech/sipe/fintech/external/service/ExternalTransferApiImpl.kt
+++ b/src/main/kotlin/tech/sipe/fintech/external/service/ExternalTransferApiImpl.kt
@@ -1,0 +1,15 @@
+package tech.sipe.fintech.external.service
+
+import org.springframework.stereotype.Component
+import tech.sipe.fintech.external.ExternalTransferApi
+
+@Component
+class ExternalTransferApiImpl : ExternalTransferApi {
+	override fun transfer(
+		sourceAccountNumber: String,
+		destinationAccountNumber: String,
+		amount: Long,
+	) {
+		TODO("Not yet implemented")
+	}
+}

--- a/src/main/kotlin/tech/sipe/fintech/wallet/PayWalletInternalApi.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/PayWalletInternalApi.kt
@@ -3,11 +3,6 @@ package tech.sipe.fintech.wallet
 import tech.sipe.fintech.wallet.presentation.response.GetBalanceResponse
 
 interface PayWalletInternalApi {
-	fun charge(
-		amount: Long,
-		payWalletId: Long,
-	)
-
 	fun pay(
 		amount: Long,
 		payWalletId: Long,

--- a/src/main/kotlin/tech/sipe/fintech/wallet/WalletModuleMetadata.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/WalletModuleMetadata.kt
@@ -4,6 +4,6 @@ import org.springframework.modulith.ApplicationModule
 
 @ApplicationModule(
 	type = ApplicationModule.Type.CLOSED,
-	allowedDependencies = [],
+	allowedDependencies = ["account"],
 )
 class WalletModuleMetadata

--- a/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletChargedEvent.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletChargedEvent.kt
@@ -1,0 +1,5 @@
+package tech.sipe.fintech.wallet.domain
+
+import tech.sipe.fintech.common.DomainEvent
+
+class PayWalletChargedEvent : DomainEvent

--- a/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletTransferredEvent.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletTransferredEvent.kt
@@ -1,0 +1,5 @@
+package tech.sipe.fintech.wallet.domain
+
+import tech.sipe.fintech.common.DomainEvent
+
+class PayWalletTransferredEvent : DomainEvent

--- a/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletWithdrawnEvent.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/domain/PayWalletWithdrawnEvent.kt
@@ -1,0 +1,5 @@
+package tech.sipe.fintech.wallet.domain
+
+import tech.sipe.fintech.common.DomainEvent
+
+class PayWalletWithdrawnEvent : DomainEvent

--- a/src/main/kotlin/tech/sipe/fintech/wallet/presentation/PayWalletInternalApiImpl.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/presentation/PayWalletInternalApiImpl.kt
@@ -9,13 +9,6 @@ import tech.sipe.fintech.wallet.service.PayWalletService
 class PayWalletInternalApiImpl(
 	private val payWalletService: PayWalletService,
 ) : PayWalletInternalApi {
-	override fun charge(
-		amount: Long,
-		payWalletId: Long,
-	) {
-		payWalletService.charge(amount, payWalletId)
-	}
-
 	override fun pay(
 		amount: Long,
 		payWalletId: Long,

--- a/src/main/kotlin/tech/sipe/fintech/wallet/service/PayWalletService.kt
+++ b/src/main/kotlin/tech/sipe/fintech/wallet/service/PayWalletService.kt
@@ -1,15 +1,19 @@
 package tech.sipe.fintech.wallet.service
 
 import jakarta.transaction.Transactional
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
-import tech.sipe.fintech.wallet.domain.PayWallet
-import tech.sipe.fintech.wallet.domain.PayWalletRepository
+import tech.sipe.fintech.account.Account
+import tech.sipe.fintech.external.ExternalTransferApi
+import tech.sipe.fintech.wallet.domain.*
 import tech.sipe.fintech.wallet.presentation.request.CreateWalletRequest
 import tech.sipe.fintech.wallet.presentation.response.GetBalanceResponse
 
 @Service
 class PayWalletService(
 	private val payWalletRepository: PayWalletRepository,
+	private val externalTransferApi: ExternalTransferApi,
+	private val eventPublisher: ApplicationEventPublisher,
 ) {
 	@Transactional
 	fun create(createWalletRequest: CreateWalletRequest) {
@@ -21,21 +25,11 @@ class PayWalletService(
 		payWalletRepository.save(payWallet)
 	}
 
-	@Transactional
-	fun charge(
-		amount: Long,
-		userId: Long,
-	) {
-		/**
-		 * 1. 지갑 조회
-		 * 2. amount 만큼 충전
-		 * 3. 지갑 저장
-		 */
-		val payWallet: PayWallet = payWalletRepository.findByUserId(userId)
-		payWallet.charge(amount)
-		payWalletRepository.save(payWallet)
-	}
-
+	/*
+	 * TODO
+	 * pay 메소드도 이체하는 동작이 필요한가?
+	 * 그럼 결제 모듈의 역할은?
+	 */
 	@Transactional
 	fun pay(
 		amount: Long,
@@ -58,5 +52,65 @@ class PayWalletService(
 		 */
 		val payWallet: PayWallet = payWalletRepository.findByPayWalletId(payWalletId)
 		return GetBalanceResponse(payWallet.balance)
+	}
+
+	@Transactional
+	fun charge(
+		amount: Long,
+		userId: Long,
+	) {
+		val payWallet: PayWallet = payWalletRepository.findByUserId(userId)
+		payWallet.charge(amount)
+		payWalletRepository.save(payWallet)
+
+		// FIXME 계좌 조회 mocking -> 계좌 API 로 조회 필요
+		val userAccount = Account() // findByUserId
+		val corpAccount = Account()
+		externalTransferApi.transfer(
+			sourceAccountNumber = userAccount.accountNo,
+			destinationAccountNumber = corpAccount.accountNo,
+			amount = amount,
+		)
+
+		eventPublisher.publishEvent(PayWalletChargedEvent())
+	}
+
+	@Transactional
+	fun withdraw(
+		amount: Long,
+		userId: Long,
+	) {
+		val payWallet: PayWallet = payWalletRepository.findByUserId(userId)
+		payWallet.withdraw(amount)
+		payWalletRepository.save(payWallet)
+
+		// FIXME 계좌 조회 mocking -> 계좌 API 로 조회 필요
+		val userAccount = Account() // findByUserId
+		val corpAccount = Account()
+		externalTransferApi.transfer(
+			sourceAccountNumber = corpAccount.accountNo,
+			destinationAccountNumber = userAccount.accountNo,
+			amount = amount,
+		)
+
+		eventPublisher.publishEvent(PayWalletWithdrawnEvent())
+	}
+
+	@Transactional
+	fun transfer(
+		sourceUserId: Long,
+		destinationUserId: Long,
+		amount: Long,
+	) {
+		val sourcePayWallet: PayWallet = payWalletRepository.findByUserId(sourceUserId)
+		val destinationPayWallet: PayWallet = payWalletRepository.findByUserId(destinationUserId)
+
+		sourcePayWallet.withdraw(amount)
+		destinationPayWallet.charge(amount)
+
+		payWalletRepository.save(sourcePayWallet)
+		payWalletRepository.save(destinationPayWallet)
+
+		eventPublisher.publishEvent(PayWalletTransferredEvent())
 	}
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이 사항
- 지갑 모듈의 충전, 출금, 송금 동작을 구현했습니다.
- 각 동작은 도메인 이벤트를 발행합니다. (추후 송금 모듈에 리스너 구현 필요)

## 📝 논의가 필요한 부분
- pay() 동작과 withdraw() 동작의 차이가 계좌 이체 시 받는쪽이 달라진다는 것 말고는 없네요.🤔
- 제일 최근에 말씀 나눴던 것 처럼 지갑 도메인에서 {지갑 차감 → 계좌 이체} 의 동작을 모두 수행하도록 변경했습니다.
  - 막상 이렇게 바꾸니 또 지갑 모듈에만 로직이 너무 몰린 느낌입니다.
  - 이러면 결제 모듈도 지갑 모듈에 메소드 호출하는 것 말곤 동작이 없겠어요.

## 📚 기타
- [상준님께서 지갑 모듈 작업해주신 PR](https://github.com/sipe-team/3-2_smart_fintech/pull/25) 이 머지가 안되어서 우선 해당 PR 브랜치를 base 로 했습니다.
